### PR TITLE
Add synthetic instrument helper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # risk-tools
+
+This repository contains a small portfolio optimisation toolkit used in
+examples and tests.  The main functionality lives in
+`opt/src/opt/portfolio_core.py`.
+
+## Synthetic instruments
+
+The latest release adds support for *synthetic instruments* such as index
+futures or ETFs.  Synthetic instruments are represented via their underlying
+compositions which allows risk to be modelled on the constituents while the
+synthetic itself remains a separate tradeable instrument.
+
+To define a synthetic instrument supply a mapping of underlying instrument
+weights and (optionally) a cost model or alpha overlay:
+
+```python
+from opt.synthetic import SyntheticInstrument
+
+syn = SyntheticInstrument(
+    name="ES1",
+    weights={"SPY": 1.0},
+    alpha_overlay=0.001,
+)
+```
+
+Use :func:`opt.portfolio_core.apply_synthetics` to extend an existing
+``ProblemConfig`` with a collection of synthetic instruments.  Individual
+synthetic cost models are combined using
+:class:`opt.synthetic.PerInstrumentCostModel` and automatically placed in the
+resulting config.
+
+Raw instrument definitions can be loaded from CSV using
+:func:`opt.synthetic.load_synthetics_csv`.

--- a/opt/src/opt/synthetic.py
+++ b/opt/src/opt/synthetic.py
@@ -1,0 +1,137 @@
+# Synthetic instrument support
+
+from __future__ import annotations
+
+import csv
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .portfolio_core import InstrumentMap, TransactionCostModel, OptBaseModel
+
+
+
+
+class SyntheticInstrument(OptBaseModel):
+    """Definition of a synthetic instrument.
+
+    Parameters
+    ----------
+    name:
+        Name of the synthetic instrument.
+    weights:
+        Mapping from underlying instrument name to the weight of that
+        instrument in the synthetic.
+    cost_model:
+        Optional cost model used when trading this synthetic.
+    alpha_overlay:
+        Extra alpha applied on top of the implied alpha from the
+        underlying instruments.
+    """
+
+    name: str
+    weights: Mapping[str, float]
+    cost_model: Optional[Any] = None
+    alpha_overlay: float = 0.0
+
+    def implied_exposures(self, base_map: InstrumentMap) -> NDArray[np.floating]:
+        """Return synthetic exposure vector implied by *base_map*."""
+        idx = {n: i for i, n in enumerate(base_map.names_decision)}
+        exp = np.zeros(base_map.E.shape[0])
+        for inst, w in self.weights.items():
+            j = idx[inst]
+            exp += w * base_map.E[:, j]
+        return exp
+
+    def implied_alpha(self, alpha_map: Mapping[str, float]) -> float:
+        """Return synthetic alpha from underlying alphas."""
+        a = sum(alpha_map[n] * w for n, w in self.weights.items())
+        return a + self.alpha_overlay
+
+
+def load_synthetics_csv(path: str) -> List[SyntheticInstrument]:
+    """Load :class:`SyntheticInstrument` objects from ``CSV`` file.
+
+    The CSV file must contain the columns ``name``, ``underlying`` and
+    ``weight``.  An optional column ``alpha_overlay`` may be supplied to
+    specify per-instrument overlays.  Multiple rows with the same ``name``
+    are aggregated into a single synthetic instrument.
+    """
+
+    by_name: Dict[str, Dict[str, float]] = {}
+    overlay: Dict[str, float] = {}
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = row["name"]
+            u = row["underlying"]
+            w = float(row["weight"])
+            by_name.setdefault(name, {})[u] = w
+            if "alpha_overlay" in row and row["alpha_overlay"]:
+                overlay[name] = float(row["alpha_overlay"])
+    out = []
+    for name, weights in by_name.items():
+        out.append(
+            SyntheticInstrument(
+                name=name,
+                weights=weights,
+                alpha_overlay=overlay.get(name, 0.0),
+            )
+        )
+    return out
+
+
+from .portfolio_core import InstrumentMap, TransactionCostModel, OptBaseModel
+
+
+class PerInstrumentCostModel(OptBaseModel):
+    """Wrapper allowing different cost models per decision variable."""
+
+    models: Sequence[Optional[Any]]
+
+    def cost_soc(self, M: "mf.Model", delta_dec: "mf.Expr") -> "mf.Expr":  # noqa: F821
+        import mosek.fusion as mf
+
+        exprs = []
+        for i, cm in enumerate(self.models):
+            if cm is None:
+                continue
+            slice_i = delta_dec.pick([i])
+            exprs.append(cm.cost_soc(M, slice_i))
+        if not exprs:
+            return 0.0
+        return mf.sum(mf.vstack(exprs))
+
+
+def extend_instrument_map(
+    base_map: InstrumentMap,
+    base_alpha: NDArray[np.floating],
+    synthetics: Iterable[SyntheticInstrument],
+    base_cost_model: Optional[TransactionCostModel] = None,
+) -> Tuple[InstrumentMap, NDArray[np.floating], List[Optional[TransactionCostModel]]]:
+    """Extend ``base_map`` with ``synthetics``.
+
+    Returns new instrument map, new ``alpha_dec`` vector and list of cost
+    models aligned with the decision variables.
+    """
+
+    n_risk, n_dec = base_map.E.shape
+    E_parts = [base_map.E]
+    alpha_list = list(base_alpha)
+    cost_models: List[Optional[TransactionCostModel]] = []
+    for _ in range(n_dec):
+        cost_models.append(base_cost_model)
+
+    alpha_map = {n: a for n, a in zip(base_map.names_decision, base_alpha)}
+    names_decision = list(base_map.names_decision)
+
+    for s in synthetics:
+        E_parts.append(s.implied_exposures(base_map)[:, None])
+        alpha_list.append(s.implied_alpha(alpha_map))
+        cost_models.append(s.cost_model)
+        names_decision.append(s.name)
+
+    E_new = np.hstack(E_parts)
+    imap = InstrumentMap(E=E_new, names_risk=base_map.names_risk, names_decision=names_decision)
+    return imap, np.array(alpha_list, dtype=float), cost_models

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "opt", "src"))
+
+from opt.portfolio_core import (
+    InstrumentMap,
+    FactorRiskModel, FactorRiskModelData,
+    ProblemConfig, UtilityConfig,
+    PowerLawCost,
+    apply_synthetics,
+)
+from opt.synthetic import SyntheticInstrument
+
+
+def base_config():
+    imap = InstrumentMap.identity(2)
+    alpha = np.array([0.1, 0.2])
+    frmd = FactorRiskModelData(
+        loadings=np.eye(2),
+        factor_cov=np.eye(2),
+        specific_var=np.array([0.1, 0.1]),
+    )
+    cfg = ProblemConfig(
+        risk_model=FactorRiskModel(data=frmd),
+        instrument_map=imap,
+        alpha_dec=alpha,
+        utility=UtilityConfig(cost_model=PowerLawCost(scale=0.01)),
+    )
+    return cfg
+
+
+def test_extend_and_apply_synthetic():
+    cfg = base_config()
+    syn = SyntheticInstrument(
+        name="SYN",
+        weights={"A0": 0.5, "A1": 0.5},
+        cost_model=PowerLawCost(scale=0.02),
+        alpha_overlay=0.01,
+    )
+    new_cfg = apply_synthetics(cfg, [syn])
+
+    # instrument names extended
+    assert new_cfg.instrument_map.names_decision == ["A0", "A1", "SYN"]
+    # synthetic exposures are averages of the two columns
+    np.testing.assert_allclose(new_cfg.instrument_map.E[:, 2], [0.5, 0.5])
+    # alpha with overlay
+    assert np.isclose(new_cfg.alpha_dec[2], 0.16)
+    # cost model wrapper
+    assert len(new_cfg.utility.cost_model.models) == 3


### PR DESCRIPTION
## Summary
- document how to extend a ProblemConfig with synthetic instruments
- introduce `apply_synthetics` helper in `portfolio_core`
- relax pydantic typing constraints for transaction cost models
- update models to support pydantic v2
- add unit test for synthetic instrument integration

## Testing
- `python -m py_compile opt/src/opt/portfolio_core.py opt/src/opt/synthetic.py tests/test_synthetic.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e96b7b43083268800fd788430b8f8