### PR TITLE
Improve PortfolioResult handling of Mosek expressions

### DIFF
--- a/opt/src/opt/result.py
+++ b/opt/src/opt/result.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.typing import NDArray
+from pydantic import model_validator
 
 from .core import OptBaseModel
 
@@ -11,3 +12,20 @@ class PortfolioResult(OptBaseModel):
     risk_sys: float
     risk_spec: float
     cost: float
+
+    @staticmethod
+    def _as_numpy(v: object) -> object:
+        """Return numbers/arrays from MOSEK expressions or raw values."""
+        if hasattr(v, "level"):
+            v = v.level()
+        return np.asarray(v, dtype=float) if np.ndim(v) else float(v)
+
+    @model_validator(mode="before")
+    def _coerce(cls, values: dict) -> dict:  # noqa: D401,N805 - pydantic API
+        """Coerce MOSEK expression types into plain numpy types."""
+        out = dict(values)
+        for k in ("decision_weights", "exposure_weights"):
+            out[k] = cls._as_numpy(out[k])
+        for k in ("obj_value", "risk_sys", "risk_spec", "cost"):
+            out[k] = float(cls._as_numpy(out[k]))
+        return out

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "opt", "src"))
+
+from opt.result import PortfolioResult
+
+
+class DummyExpr:
+    def __init__(self, val):
+        self.val = val
+
+    def level(self):
+        return self.val
+
+
+def test_result_instantiation_from_expr():
+    dec = DummyExpr([0.1, 0.2])
+    exp = DummyExpr([0.3, 0.4])
+    res = PortfolioResult(
+        decision_weights=dec,
+        exposure_weights=exp,
+        obj_value=DummyExpr(1.0),
+        risk_sys=DummyExpr(0.5),
+        risk_spec=DummyExpr(0.2),
+        cost=DummyExpr(0.01),
+    )
+    assert isinstance(res.decision_weights, np.ndarray)
+    np.testing.assert_allclose(res.decision_weights, [0.1, 0.2])
+    assert isinstance(res.obj_value, float) and np.isclose(res.obj_value, 1.0)


### PR DESCRIPTION
## Summary
- allow PortfolioResult to coerce Mosek `Expr` objects
- add regression test for expression coercion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fedcf15c08326a73a97dc456f5c54