### PR TITLE
Enhance portfolio builder and add diagnostics

### DIFF
--- a/opt/src/opt/diagnostics.py
+++ b/opt/src/opt/diagnostics.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import List
+
+from .config import ProblemConfig
+from .constraints import (
+    ConstraintSpec,
+    InstrumentBoundConstraint,
+    InstrumentTurnoverConstraint,
+    GrossExposureConstraint,
+    NetExposureConstraint,
+    FactorBoundConstraint,
+)
+
+
+def check_constraints(cfg: ProblemConfig) -> List[str]:
+    """Return a list of obvious consistency issues in ``cfg``."""
+    errors: List[str] = []
+    for c in cfg.constraints:
+        if isinstance(c, InstrumentBoundConstraint) and c.lower > c.upper:
+            errors.append(f"Instrument bounds for {c.idx} are inconsistent")
+        if isinstance(c, NetExposureConstraint) and c.lower > c.upper:
+            errors.append("Net exposure lower bound exceeds upper bound")
+        if isinstance(c, InstrumentTurnoverConstraint) and c.limit < 0:
+            errors.append("Turnover limit cannot be negative")
+        if isinstance(c, GrossExposureConstraint) and c.limit < 0:
+            errors.append("Gross exposure limit cannot be negative")
+        if isinstance(c, FactorBoundConstraint) and c.max_abs < 0:
+            errors.append("Factor bound max_abs cannot be negative")
+        if isinstance(c, ConstraintSpec) and getattr(c, "label", "") == "":
+            errors.append(f"Constraint {c.__class__.__name__} has no label")
+    return errors

--- a/opt/src/opt/workflow.py
+++ b/opt/src/opt/workflow.py
@@ -10,9 +10,10 @@ from .constraints import (
     FactorBoundConstraint,
     GrossExposureConstraint,
     InstrumentBoundConstraint,
-    InstrumentTurnoverConstraint,
+    TurnoverConstraint,
     NetExposureConstraint,
 )
+from .core import QuantityType
 from .instruments import InstrumentMap
 from .portfolio import Portfolio
 from .risk import FactorRiskModel
@@ -26,12 +27,15 @@ class ProblemBuilder:
         risk_model: FactorRiskModel,
         instrument_map: InstrumentMap,
         alpha_dec: NDArray[np.floating],
+        *,
+        quantity_type: QuantityType = QuantityType.WEIGHT,
     ) -> None:
         self.risk_model = risk_model
         self.instrument_map = instrument_map
         self.alpha_dec = alpha_dec
         self.alpha_exp = np.zeros(instrument_map.shape[0])
         self.start_dec = np.zeros(instrument_map.shape[1])
+        self.quantity_type = quantity_type
         self.cost_model: Optional[Any] = None
         self.constraints: list = []
         self.risk_aversion_sys = 1.0
@@ -42,29 +46,44 @@ class ProblemBuilder:
         return self
 
     def with_start_from_portfolio(self, p: Portfolio) -> "ProblemBuilder":
-        self.start_dec = p.to_weights()
+        if self.quantity_type is QuantityType.NOTIONAL:
+            self.start_dec = p.to_notional()
+        else:
+            self.start_dec = p.to_weights()
+        return self
+
+    def add_cash(self, name: str = "CASH") -> "ProblemBuilder":
+        n_risk = self.instrument_map.shape[0]
+        E_cash = np.zeros((n_risk, 1))
+        self.instrument_map = InstrumentMap(
+            E=np.hstack([self.instrument_map.E, E_cash]),
+            names_risk=list(self.instrument_map.names_risk),
+            names_decision=self.instrument_map.names_decision + [name],
+        )
+        self.alpha_dec = np.concatenate([self.alpha_dec, [0.0]])
+        self.start_dec = np.concatenate([self.start_dec, [0.0]])
         return self
 
     def add_bounds(
         self, idx: Sequence[int], lower: float = -np.inf, upper: float = np.inf
     ) -> "ProblemBuilder":
         self.constraints.append(
-            InstrumentBoundConstraint(idx=list(idx), lower=lower, upper=upper)
+            InstrumentBoundConstraint(idx=list(idx), lower=lower, upper=upper, label="bounds")
         )
         return self
 
     def add_turnover_limit(self, limit: float) -> "ProblemBuilder":
         self.constraints.append(
-            InstrumentTurnoverConstraint(start_dec=self.start_dec, limit=limit)
+            TurnoverConstraint(start_dec=self.start_dec, limit=limit, label="turnover")
         )
         return self
 
     def add_gross_limit(self, limit: float) -> "ProblemBuilder":
-        self.constraints.append(GrossExposureConstraint(limit=limit))
+        self.constraints.append(GrossExposureConstraint(limit=limit, label="gross"))
         return self
 
     def add_net_bounds(self, lower: float = -np.inf, upper: float = np.inf) -> "ProblemBuilder":
-        self.constraints.append(NetExposureConstraint(lower=lower, upper=upper))
+        self.constraints.append(NetExposureConstraint(lower=lower, upper=upper, label="net"))
         return self
 
     def add_group_limits(self, groups: Sequence[str], max_abs: float) -> "ProblemBuilder":
@@ -72,7 +91,7 @@ class ProblemBuilder:
         B = np.zeros((len(groups), len(unique)))
         for i, g in enumerate(groups):
             B[i, unique.index(g)] = 1.0
-        self.constraints.append(FactorBoundConstraint(B=B, max_abs=max_abs))
+        self.constraints.append(FactorBoundConstraint(B=B, max_abs=max_abs, label="group"))
         return self
 
     def build(self) -> ProblemConfig:
@@ -81,7 +100,7 @@ class ProblemBuilder:
             risk_aversion_spec=self.risk_aversion_spec,
             cost_model=self.cost_model,
         )
-        return ProblemConfig(
+        cfg = ProblemConfig(
             risk_model=self.risk_model,
             instrument_map=self.instrument_map,
             alpha_dec=self.alpha_dec,
@@ -90,6 +109,12 @@ class ProblemBuilder:
             utility=util,
             constraints=list(self.constraints),
         )
+        from .diagnostics import check_constraints
+
+        errs = check_constraints(cfg)
+        if errs:
+            raise ValueError("Invalid constraint configuration: " + "; ".join(errs))
+        return cfg
 
 
 def make_long_only_problem(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "opt", "src"))
+
+from opt.instruments import InstrumentMap
+from opt.risk import FactorRiskModel, FactorRiskModelData
+from opt.workflow import ProblemBuilder
+from opt.diagnostics import check_constraints
+
+
+def test_check_constraints_reports_unlabelled():
+    n = 2
+    imap = InstrumentMap.identity(n)
+    alpha = np.array([0.1, 0.2])
+    frmd = FactorRiskModelData(loadings=np.eye(n), factor_cov=np.eye(n), specific_var=0.1 * np.ones(n))
+    rm = FactorRiskModel(data=frmd)
+    builder = ProblemBuilder(risk_model=rm, instrument_map=imap, alpha_dec=alpha)
+    builder.add_bounds(range(n), 0.0, 0.5)
+    cfg = builder.build()
+    errors = check_constraints(cfg)
+    assert not errors  # bounds labelled by builder

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "opt", "src"))
 from opt.instruments import InstrumentMap
 from opt.risk import FactorRiskModel, FactorRiskModelData
 from opt.workflow import ProblemBuilder, make_long_only_problem
+from opt.core import QuantityType
 from opt.costs import PowerLawCost
 from opt.optimizer import optimize_portfolio
 from mosek.fusion import OptimizeError
@@ -55,3 +56,18 @@ def test_make_long_only_problem():
 
     res = _solve_or_skip(cfg)
     assert res.decision_weights.shape[0] == n
+
+
+def test_builder_notional_and_cash():
+    n = 3
+    imap = InstrumentMap.identity(n)
+    alpha = np.linspace(0.1, 0.3, n)
+    loadings = np.eye(n)
+    frmd = FactorRiskModelData(loadings=loadings, factor_cov=np.eye(n), specific_var=0.1 * np.ones(n))
+    rm = FactorRiskModel(data=frmd)
+
+    builder = ProblemBuilder(risk_model=rm, instrument_map=imap, alpha_dec=alpha, quantity_type=QuantityType.NOTIONAL)
+    builder.add_cash()
+    cfg = builder.build()
+
+    assert cfg.instrument_map.shape[1] == n + 1


### PR DESCRIPTION
## Summary
- add optional labels for constraints
- support portfolio diagnostics with a new `check_constraints` helper
- extend `ProblemBuilder` with quantity type, cash instrument and labelled constraints
- expose turnover constraint alias
- new tests for diagnostics and notional workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff4ca32a48326b3152950d6bad3eb