### PR TITLE
Improve handling of MOSEK expressions

### DIFF
--- a/opt/src/opt/optimizer.py
+++ b/opt/src/opt/optimizer.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from .config import ProblemConfig
 from .result import PortfolioResult
+from .utils import value_of
 
 try:
     import mosek.fusion as mf
@@ -66,12 +67,9 @@ class ConvexFactorOptimizer:
             M.setLogHandler(None)
             M.solve()
 
-            w_dec_val = w_dec.level()
+            w_dec_val = value_of(w_dec)
             if cfg.utility.cost_model is not None:
-                if hasattr(cost_expr, "level"):
-                    cost_val = float(cost_expr.level()[0])
-                else:
-                    cost_val = float(cost_expr)
+                cost_val = float(np.ravel(value_of(cost_expr))[0])
             else:
                 cost_val = 0.0
 
@@ -79,8 +77,8 @@ class ConvexFactorOptimizer:
                 decision_weights=w_dec_val,
                 exposure_weights=E @ w_dec_val,
                 obj_value=M.primalObjValue(),
-                risk_sys=t_sys.level()[0],
-                risk_spec=t_spec.level()[0],
+                risk_sys=float(np.ravel(value_of(t_sys))[0]),
+                risk_spec=float(np.ravel(value_of(t_spec))[0]),
                 cost=cost_val,
             )
 

--- a/opt/src/opt/result.py
+++ b/opt/src/opt/result.py
@@ -3,6 +3,7 @@ from numpy.typing import NDArray
 from pydantic import model_validator
 
 from .core import OptBaseModel
+from .utils import value_of
 
 
 class PortfolioResult(OptBaseModel):
@@ -16,9 +17,7 @@ class PortfolioResult(OptBaseModel):
     @staticmethod
     def _as_numpy(v: object) -> object:
         """Return numbers/arrays from MOSEK expressions or raw values."""
-        if hasattr(v, "level"):
-            v = v.level()
-        return np.asarray(v, dtype=float) if np.ndim(v) else float(v)
+        return value_of(v)
 
     @model_validator(mode="before")
     def _coerce(cls, values: dict) -> dict:  # noqa: D401,N805 - pydantic API

--- a/opt/src/opt/utils.py
+++ b/opt/src/opt/utils.py
@@ -1,5 +1,11 @@
 """Utility functions for optimisation components."""
 
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
 
 def abs_expr(M: "mf.Model", x: "mf.Expr", name: str) -> "mf.Var":  # noqa: F821
     """Return non-negative *u* with u \u2265 |x| element-wise."""
@@ -7,3 +13,41 @@ def abs_expr(M: "mf.Model", x: "mf.Expr", name: str) -> "mf.Var":  # noqa: F821
     M.constraint(x <= u)
     M.constraint(-x <= u)
     return u
+
+
+def value_of(obj: Any) -> Any:
+    """Return numeric data from MOSEK expressions or Python objects.
+
+    Scalars are returned as ``float`` while larger results are returned as
+    :class:`numpy.ndarray`.  The helper attempts the following strategies:
+
+    #. Call ``obj.level()`` if available (for variables and parameters).
+    #. If MOSEK is present and ``obj`` is an expression, evaluate it using a
+       :class:`mosek.fusion.WorkStack`.
+    #. Fallback to ``numpy.asarray`` for anything else.
+    """
+
+    if hasattr(obj, "level"):
+        try:
+            obj = obj.level()
+        except Exception:
+            pass
+
+    try:
+        import mosek.fusion as mf
+    except Exception:  # pragma: no cover - MOSEK not installed
+        mf = None
+
+    if mf is not None and isinstance(obj, mf.Expr):
+        from mosek.fusion import WorkStack
+
+        rs, ws, xs = WorkStack(), WorkStack(), WorkStack()
+        n = int(obj.getSize())
+        rs.allocf64(n)
+        obj.eval(rs, ws, xs)
+        vec = [rs.popf64() for _ in range(n)]
+        arr = np.array(vec, dtype=float).reshape(obj.getShape())
+        return arr if arr.ndim else float(arr)
+
+    arr = np.asarray(obj, dtype=float)
+    return arr if arr.ndim else float(arr)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -5,6 +5,7 @@ import numpy as np
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "opt", "src"))
 
 from opt.result import PortfolioResult
+from opt.utils import value_of
 
 
 class DummyExpr:
@@ -29,3 +30,44 @@ def test_result_instantiation_from_expr():
     assert isinstance(res.decision_weights, np.ndarray)
     np.testing.assert_allclose(res.decision_weights, [0.1, 0.2])
     assert isinstance(res.obj_value, float) and np.isclose(res.obj_value, 1.0)
+
+
+class FakeWorkStack:
+    def __init__(self):
+        self.data = []
+
+    def allocf64(self, n):
+        self.data = []
+
+    def pushf64(self, x):
+        self.data.append(float(x))
+
+    def popf64(self):
+        return self.data.pop()
+
+
+class FakeExpr:
+    def __init__(self, val):
+        self.arr = np.asarray(val, dtype=float)
+
+    def getSize(self):
+        return self.arr.size
+
+    def getShape(self):
+        return self.arr.shape
+
+    def eval(self, rs, ws, xs):
+        for v in reversed(self.arr.ravel()):
+            rs.pushf64(v)
+
+
+def test_value_of_mosek_like_expr(monkeypatch):
+    import types
+
+    fake_mod = types.SimpleNamespace(Expr=FakeExpr, WorkStack=FakeWorkStack)
+    monkeypatch.setitem(sys.modules, "mosek", types.ModuleType("mosek"))
+    monkeypatch.setitem(sys.modules, "mosek.fusion", fake_mod)
+
+    expr = FakeExpr([[1.0, 2.0], [3.0, 4.0]])
+    val = value_of(expr)
+    np.testing.assert_allclose(val, [[1.0, 2.0], [3.0, 4.0]])


### PR DESCRIPTION
## Summary
- handle MOSEK Expr values gracefully in `PortfolioResult`
- add `value_of` helper for evaluating MOSEK expressions
- update optimizer to use new helper
- test `value_of` with a MOSEK-like fake expression
- document `value_of`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ff8bf26b8832689fc738209599927