### PR TITLE
Improve optimizer status checks and config setup

### DIFF
--- a/opt/src/opt/workflow.py
+++ b/opt/src/opt/workflow.py
@@ -122,8 +122,15 @@ def make_long_only_problem(
     instrument_map: InstrumentMap,
     alpha_dec: NDArray[np.floating],
     groups: Sequence[str],
+    *,
+    quantity_type: QuantityType = QuantityType.WEIGHT,
 ) -> ProblemConfig:
-    builder = ProblemBuilder(risk_model, instrument_map, alpha_dec)
+    builder = ProblemBuilder(
+        risk_model=risk_model,
+        instrument_map=instrument_map,
+        alpha_dec=alpha_dec,
+        quantity_type=quantity_type,
+    )
     n = instrument_map.shape[1]
     builder.add_bounds(range(n), lower=0.0, upper=0.6)
     builder.add_gross_limit(3.0)
@@ -138,8 +145,15 @@ def make_long_short_problem(
     alpha_dec: NDArray[np.floating],
     start_dec: NDArray[np.floating],
     groups: Sequence[str],
+    *,
+    quantity_type: QuantityType = QuantityType.WEIGHT,
 ) -> ProblemConfig:
-    builder = ProblemBuilder(risk_model, instrument_map, alpha_dec)
+    builder = ProblemBuilder(
+        risk_model=risk_model,
+        instrument_map=instrument_map,
+        alpha_dec=alpha_dec,
+        quantity_type=quantity_type,
+    )
     builder.start_dec = start_dec
     builder.add_bounds(range(instrument_map.shape[1]), lower=-0.5, upper=0.5)
     builder.add_turnover_limit(0.5)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -103,7 +103,7 @@ def make_long_only_problem():
 def make_long_short_problem():
     cfg = apply_synthetics(base_config_10(), load_all_synthetics())
     n_dec = cfg.instrument_map.shape[1]
-    start = 0.1 * np.ones(n_dec)
+    start = np.zeros(n_dec)
     cfg.start_dec = start
     cfg.constraints = [
         InstrumentBoundConstraint(idx=list(range(n_dec)), lower=-0.5, upper=0.5),

--- a/tests/test_optimizer_status.py
+++ b/tests/test_optimizer_status.py
@@ -1,0 +1,30 @@
+import enum
+import types
+import sys
+import pytest
+
+from opt.optimizer import ConvexFactorOptimizer
+
+class DummyStatus(enum.Enum):
+    Optimal = 0
+    NearOptimal = 1
+    Unknown = 2
+
+class DummyError(Exception):
+    pass
+
+fake_mod = types.SimpleNamespace(SolutionStatus=DummyStatus, OptimizeError=DummyError)
+
+
+def test_check_status_raises_on_bad_status(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mosek", types.ModuleType("mosek"))
+    monkeypatch.setitem(sys.modules, "mosek.fusion", fake_mod)
+    with pytest.raises(DummyError):
+        ConvexFactorOptimizer._check_status(DummyStatus.Unknown)
+
+
+def test_check_status_ok(monkeypatch):
+    monkeypatch.setitem(sys.modules, "mosek", types.ModuleType("mosek"))
+    monkeypatch.setitem(sys.modules, "mosek.fusion", fake_mod)
+    # should not raise
+    ConvexFactorOptimizer._check_status(DummyStatus.Optimal)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "opt", "src"))
 
 from opt.instruments import InstrumentMap
 from opt.risk import FactorRiskModel, FactorRiskModelData
-from opt.workflow import ProblemBuilder, make_long_only_problem
+from opt.workflow import ProblemBuilder, make_long_only_problem, make_long_short_problem
 from opt.core import QuantityType
 from opt.costs import PowerLawCost
 from opt.optimizer import optimize_portfolio
@@ -71,3 +71,25 @@ def test_builder_notional_and_cash():
     cfg = builder.build()
 
     assert cfg.instrument_map.shape[1] == n + 1
+
+
+def test_make_long_short_notional():
+    n = 3
+    imap = InstrumentMap.identity(n)
+    alpha = np.linspace(0.1, 0.3, n)
+    loadings = np.eye(n)
+    frmd = FactorRiskModelData(loadings=loadings, factor_cov=np.eye(n), specific_var=0.1 * np.ones(n))
+    rm = FactorRiskModel(data=frmd)
+
+    start = np.zeros(n)
+    groups = ["g1"] * n
+    cfg = make_long_short_problem(
+        rm,
+        imap,
+        alpha,
+        start,
+        groups,
+        quantity_type=QuantityType.NOTIONAL,
+    )
+
+    assert cfg.start_dec.shape[0] == n


### PR DESCRIPTION
## Summary
- validate optimizer solution status after calling `solve`
- make long-short test problem feasible
- support quantity types in workflow problem helpers
- add regression tests for solver status checks and quantity-type helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860164a502083268d35251534d9228e